### PR TITLE
Implement Optional Lambda Authorizer for API Gateway

### DIFF
--- a/src/auth/auth.py
+++ b/src/auth/auth.py
@@ -1,0 +1,99 @@
+import os
+import json
+
+def lambda_handler(event, context):
+    print(f"Received event: {json.dumps(event)}") # Log the event to see its structure
+
+    # --- Get ARN --- 
+    # Try methodArn first (REST API), then routeArn (HTTP API)
+    method_arn = event.get('methodArn') 
+    if not method_arn:
+        print("Could not find 'methodArn' in the event. Trying 'routeArn'.")
+        method_arn = event.get('routeArn')
+        if not method_arn:
+             print("Could not find 'methodArn' or 'routeArn'. Cannot generate policy.")
+             # Return an unauthorized response for HTTP API Lambda authorizers instead of raising Exception
+             # Raising an exception results in a 500 error for the client
+             return {"isAuthorized": False} 
+             # For REST API: raise Exception('Unauthorized') # Or return deny policy
+    print(f"Using ARN: {method_arn}")
+
+    # --- Get Token --- 
+    # For HTTP API REQUEST authorizer (Payload 2.0), the identity source is an array
+    raw_auth_header = None
+    identity_source = event.get('identitySource')
+    if identity_source and isinstance(identity_source, list) and len(identity_source) > 0:
+        raw_auth_header = identity_source[0]
+        print(f"Found identitySource value: {raw_auth_header}")
+    # Check headers directly for Payload 1.0 or other cases
+    elif event.get('headers'):
+         # Header names might be lowercased by API Gateway
+         auth_header_key = next((k for k in event['headers'] if k.lower() == 'authorization'), None)
+         if auth_header_key:
+             raw_auth_header = event['headers'][auth_header_key]
+             print(f"Found Authorization header value: {raw_auth_header}")
+         
+    # Fallback check for authorizationToken (REST API Lambda Authorizer - TOKEN type)
+    elif event.get('authorizationToken'):
+         raw_auth_header = event.get('authorizationToken')
+         print(f"Found authorizationToken value: {raw_auth_header}")
+    else:
+         print("Could not find token in identitySource, headers, or authorizationToken field.")
+
+    # Extract token assuming 'Bearer <token>' format
+    token = None
+    if raw_auth_header:
+        parts = raw_auth_header.split()
+        if len(parts) == 2 and parts[0].lower() == 'bearer':
+            token = parts[1]
+            print("Successfully extracted Bearer token.")
+        else:
+             print("Authorization header format is not 'Bearer <token>'.")
+             # Treat non-bearer token as invalid for this example
+             pass # token remains None
+    else:
+        print("No raw authorization header value found.")
+    
+    # Check if token was extracted
+    if not token:
+        print("Token not found or invalid format.")
+        # Return unauthorized for HTTP API simple response
+        return {"isAuthorized": False}
+        # For REST API: raise Exception('Unauthorized') # Or return deny policy
+
+    # --- Placeholder for actual token validation --- 
+    # Replace this with your actual token validation logic (e.g., JWT verification, DB lookup)
+    print(f"Validating token (placeholder): {token}")
+    is_valid_token = True # Replace with actual validation result
+
+    if is_valid_token:
+        print("Token is valid (placeholder). Authorizing request.")
+        # For HTTP API simple response, just return True
+        return {"isAuthorized": True} 
+        # --- For REST API IAM Policy response (Example) ---
+        # principal_id = "user|a1b2c3d4" # Unique identifier for the user
+        # policy = AuthPolicy(principal_id, context.aws_request_id.replace('-', ''))
+        # policy.restApiId = api_gateway_arn_tmp[0]
+        # policy.region = api_gateway_arn_tmp[1]
+        # policy.stage = api_gateway_arn_tmp[2]
+        # policy.allowAllMethods() # Or specify allowed methods/resources
+        # auth_response = policy.build()
+        # Add context if needed:
+        # auth_response['context'] = {
+        #     'stringKey': 'stringval',
+        #     'numberKey': 123,
+        #     'booleanKey': True
+        # }
+        # return auth_response
+    else:
+        print("Token is invalid (placeholder). Denying request.")
+        # Return unauthorized for HTTP API simple response
+        return {"isAuthorized": False}
+        # For REST API: raise Exception('Unauthorized') # Or return deny policy
+
+
+# --- Example AuthPolicy class for REST API IAM Policy response ---
+# (Include this class if you need to return IAM policies for REST APIs)
+# class AuthPolicy(object):
+#     # ... (Implementation of AuthPolicy class) ...
+#     pass 


### PR DESCRIPTION
This PR introduces an optional Lambda-based request authorizer for the API Gateway endpoint, enhancing security for the MCP server deployment.

**Changes:**

*   **Authorizer Lambda Function:**
    *   Added a new Python Lambda function at `src/auth/auth.py`.
    *   This function currently implements placeholder logic: it checks for an `Authorization: Bearer <token>` header and allows the request if the format is correct. Real token validation logic should be added here.
*   **Deployment Script (`deploy.py`) Updates:**
    *   Added a new function `deploy_authorizer_lambda` to handle the packaging and deployment of the Python authorizer function.
    *   Introduced a new command-line flag `--enable-authorizer` to conditionally deploy and enable the authorizer.
    *   The `--authorizer-function-name` argument is now required only when `--enable-authorizer` is used.
    *   Modified `deploy_api_gateway` to:
        *   Conditionally create/update the Lambda authorizer resource in API Gateway.
        *   Conditionally add invoke permissions for the authorizer Lambda.
        *   Set route `AuthorizationType` to `CUSTOM` (with the deployed authorizer) or `NONE` based on whether the authorizer is enabled.
    *   Fixed a typo (`EnableSimpleResponse` -> `EnableSimpleResponses`) in authorizer configuration calls.
    *   Removed the unused `$default` API Gateway route configuration.
*   **Documentation (`README.md`):**
    *   Added a new "Authorization" section explaining how the feature works.
    *   Included example `deploy.py` commands for deploying with and without the authorizer.
    *   Provided an example `curl` command demonstrating how to make an authorized request using the `Authorization: Bearer <token>` header.

**How to Use:**

1.  **Deploy with Authorization Enabled:**
    ```bash
    python deploy.py \\
      --function-name <your-main-lambda-name> \\
      --role-arn <your-lambda-execution-role-arn> \\
      --api-gateway \\
      --enable-authorizer \\
      --authorizer-function-name <your-authorizer-lambda-name> \\
      # Add other options like --region, --image-uri etc. as needed
    ```
2.  **Deploy without Authorization (Open Endpoint):**
    ```bash
    python deploy.py \\
      --function-name <your-main-lambda-name> \\
      --role-arn <your-lambda-execution-role-arn> \\
      --api-gateway \\
      # Add other options like --region, --image-uri etc. as needed
    ```
3.  **Making Authorized Requests (if enabled):**
    ```bash
    # Replace <api-url> with your deployment output URL
    # Replace MyTestToken with your actual token if implementing real validation
    curl -XPOST "<api-url>/mcp" \\
      -H "Content-Type: application/json" \\
      -H "Accept: application/json, text/event-stream" \\
      -H "Authorization: Bearer MyTestToken" \\
      -d '{"jsonrpc": "2.0","method": "initialize", ... }' | cat
    ```
    (If deployed without the authorizer, simply omit the `-H "Authorization: ..."` header).
